### PR TITLE
chore: fix `.proto` file check

### DIFF
--- a/scripts/buf_generate.sh
+++ b/scripts/buf_generate.sh
@@ -9,7 +9,7 @@ function bufgen() {
     DIR=$2 # Path to dir containing protos to generate
 
     # Skip if ${DIR}/*.proto does not exist
-    if ! test -n "$(find "${DIR}" -maxdepth 1 -name '*.proto')"; then
+    if ! find "${DIR}" -maxdepth 1 -name '*.proto' -print -quit | grep -q .; then
       return
     fi
 


### PR DESCRIPTION
i’ve updated the `.proto` file check to make it more reliable. The old approach with `test -n "$(find ...)"` could cause issues, so I replaced it with:

```bash
find "${DIR}" -maxdepth 1 -name '*.proto' -print -quit | grep -q .
```

This way, `find` stops as soon as it finds a file, and `grep -q .` checks if anything was found. It’s faster and avoids potential errors.